### PR TITLE
fix: use `rosewater` as selection color

### DIFF
--- a/install.py
+++ b/install.py
@@ -69,7 +69,7 @@ for flavour, colours in palette.items():
     dconf_set(f":{uuid}/background-color", colours["base"]["hex"])
     dconf_set(f":{uuid}/foreground-color", colours["text"]["hex"])
     dconf_set(f":{uuid}/highlight-colors-set", True)
-    dconf_set(f":{uuid}/highlight-background-color", colours["base"]["hex"])
+    dconf_set(f":{uuid}/highlight-background-color", colours["rosewater"]["hex"])
     dconf_set(f":{uuid}/highlight-foreground-color", colours["surface2"]["hex"])
     dconf_set(f":{uuid}/cursor-colors-set", True)
     dconf_set(f":{uuid}/cursor-background-color", colours["rosewater"]["hex"])


### PR DESCRIPTION
Text selected with the cursor had the same background color as base which made it hard to distinguish.

**Before**
![image](https://github.com/catppuccin/gnome-terminal/assets/62433257/319b2139-fa8e-4cd8-b2a9-f30db5aa23a4)

**After**
![image](https://github.com/catppuccin/gnome-terminal/assets/62433257/04ca0e5c-45b9-477f-9943-05237cd04160)


