### PR TITLE
fix: default terminal profile removed from profiles list

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
 
 ## Usage
 
-1. Make sure the `dconf` and `python3` commands are available on your system.
+1. Make sure the `gsettings` and `python3` commands are available on your system.
 2. Execute the `./install.py` script, either after cloning the repository, or via `curl`:
 ```bash
 curl -L https://raw.githubusercontent.com/catppuccin/gnome-terminal/v0.2.0/install.py | python3 -

--- a/install.py
+++ b/install.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 import json
-import os
 import argparse
 from urllib.request import urlopen
 from subprocess import check_output as run
@@ -29,6 +28,7 @@ else:
         exit(1)
 
 dconf_root = "/org/gnome/terminal/legacy/profiles:"
+gsettings_schema = "org.gnome.Terminal.ProfilesList"
 # hardcoded uuids for each flavour
 uuids = {
     "mocha": "95894cfd-82f7-430d-af6e-84d168bc34f5",
@@ -38,9 +38,9 @@ uuids = {
 }
 
 
-def dconf_get(path: str):
+def gsettings_get(key: str):
     return json.loads(
-        run(["dconf", "read", f"{dconf_root}/{path}"]).decode("utf-8").replace("'", '"')
+        run(["gsettings", "get", gsettings_schema, key]).decode("utf-8").replace("'", '"')
     )
 
 
@@ -59,7 +59,7 @@ def dconf_set(path: str, data: Union[dict, list, str, bool]) -> None:
 
 # handle the case where there are no profiles
 try:
-    profiles = dconf_get("list")
+    profiles = gsettings_get("list")
 except:
     profiles = []
 

--- a/install.py
+++ b/install.py
@@ -27,7 +27,7 @@ else:
         print(f"Error fetching the palette: {e}")
         exit(1)
 
-dconf_root = "/org/gnome/terminal/legacy/profiles:"
+gsettings_path_base = "org.gnome.Terminal.Legacy.Profile:/org/gnome/terminal/legacy/profiles:/"
 gsettings_schema = "org.gnome.Terminal.ProfilesList"
 # hardcoded uuids for each flavour
 uuids = {
@@ -44,17 +44,20 @@ def gsettings_get(key: str):
     )
 
 
-def dconf_set(path: str, data: Union[dict, list, str, bool]) -> None:
-    if type(data) in [dict, list]:
-        data = json.dumps(data).replace('"', "'")
-    elif type(data) == str:
-        data = f"'{data}'"
-    elif type(data) == bool:
-        data = str(data).lower()
+def gsettings_set_key(key: str, value: Union[dict, list, str, bool], path: str = "") -> None:
+    if type(value) in [dict, list]:
+        value = json.dumps(value).replace('"', "'")
+    elif type(value) == str:
+        value = f"'{value}'"
+    elif type(value) == bool:
+        value = str(value).lower()
 
-    print(f"Setting {path} to {data}")
-
-    run(["dconf", "write", f"{dconf_root}/{path}", f"{data}"])
+    if path:
+        print(f"Setting {path}/ {key} to {value}")
+        run(["gsettings", "set", f"{gsettings_path_base}:{path}/", f"{key}", f"{value}"])
+    else:
+        print(f"Setting {key} to {value}")
+        run(["gsettings", "set", f"{gsettings_schema}", f"{key}", f"{value}"])
 
 
 # handle the case where there are no profiles
@@ -65,15 +68,15 @@ except:
 
 for flavour, colours in palette.items():
     uuid = uuids[flavour]
-    dconf_set(f":{uuid}/visible-name", f"Catppuccin {flavour.capitalize()}")
-    dconf_set(f":{uuid}/background-color", colours["base"]["hex"])
-    dconf_set(f":{uuid}/foreground-color", colours["text"]["hex"])
-    dconf_set(f":{uuid}/highlight-colors-set", True)
-    dconf_set(f":{uuid}/highlight-background-color", colours["rosewater"]["hex"])
-    dconf_set(f":{uuid}/highlight-foreground-color", colours["surface2"]["hex"])
-    dconf_set(f":{uuid}/cursor-colors-set", True)
-    dconf_set(f":{uuid}/cursor-background-color", colours["rosewater"]["hex"])
-    dconf_set(f":{uuid}/cursor-foreground-color", colours["base"]["hex"])
+    gsettings_set_key("visible-name", f"Catppuccin {flavour.capitalize()}", f"{uuid}")
+    gsettings_set_key("background-color", colours["base"]["hex"], f"{uuid}")
+    gsettings_set_key("foreground-color", colours["text"]["hex"], f"{uuid}")
+    gsettings_set_key("highlight-colors-set", True, f"{uuid}")
+    gsettings_set_key("highlight-background-color", colours["rosewater"]["hex"], f"{uuid}")
+    gsettings_set_key("highlight-foreground-color", colours["surface2"]["hex"], f"{uuid}")
+    gsettings_set_key("cursor-colors-set", True, f"{uuid}")
+    gsettings_set_key("cursor-background-color", colours["rosewater"]["hex"], f"{uuid}")
+    gsettings_set_key("cursor-foreground-color", colours["base"]["hex"], f"{uuid}")
 
     isLatte = flavour == "latte"
     colors = [
@@ -94,12 +97,12 @@ for flavour, colours in palette.items():
         colours["teal"],
         isLatte and colours["surface1"] or colours["subtext0"],
     ]
-    dconf_set(f":{uuid}/use-theme-colors", False)
+    gsettings_set_key("use-theme-colors", False, f"{uuid}")
     # get only the hex key from each entry in colors
-    dconf_set(f":{uuid}/palette", [color["hex"] for color in colors])
+    gsettings_set_key("palette", [color["hex"] for color in colors], f"{uuid}")
 
     if uuid not in profiles:
         profiles.append(uuid)
 
-dconf_set("list", profiles)
+gsettings_set_key("list", profiles)
 print("All profiles installed.")

--- a/install.py
+++ b/install.py
@@ -44,7 +44,7 @@ def gsettings_get(key: str):
     )
 
 
-def gsettings_set_key(key: str, value: Union[dict, list, str, bool], path: str = "") -> None:
+def gsettings_set(key: str, value: Union[dict, list, str, bool], path: str = "") -> None:
     if type(value) in [dict, list]:
         value = json.dumps(value).replace('"', "'")
     elif type(value) == str:
@@ -68,15 +68,15 @@ except:
 
 for flavour, colours in palette.items():
     uuid = uuids[flavour]
-    gsettings_set_key("visible-name", f"Catppuccin {flavour.capitalize()}", f"{uuid}")
-    gsettings_set_key("background-color", colours["base"]["hex"], f"{uuid}")
-    gsettings_set_key("foreground-color", colours["text"]["hex"], f"{uuid}")
-    gsettings_set_key("highlight-colors-set", True, f"{uuid}")
-    gsettings_set_key("highlight-background-color", colours["rosewater"]["hex"], f"{uuid}")
-    gsettings_set_key("highlight-foreground-color", colours["surface2"]["hex"], f"{uuid}")
-    gsettings_set_key("cursor-colors-set", True, f"{uuid}")
-    gsettings_set_key("cursor-background-color", colours["rosewater"]["hex"], f"{uuid}")
-    gsettings_set_key("cursor-foreground-color", colours["base"]["hex"], f"{uuid}")
+    gsettings_set("visible-name", f"Catppuccin {flavour.capitalize()}", f"{uuid}")
+    gsettings_set("background-color", colours["base"]["hex"], f"{uuid}")
+    gsettings_set("foreground-color", colours["text"]["hex"], f"{uuid}")
+    gsettings_set("highlight-colors-set", True, f"{uuid}")
+    gsettings_set("highlight-background-color", colours["rosewater"]["hex"], f"{uuid}")
+    gsettings_set("highlight-foreground-color", colours["surface2"]["hex"], f"{uuid}")
+    gsettings_set("cursor-colors-set", True, f"{uuid}")
+    gsettings_set("cursor-background-color", colours["rosewater"]["hex"], f"{uuid}")
+    gsettings_set("cursor-foreground-color", colours["base"]["hex"], f"{uuid}")
 
     isLatte = flavour == "latte"
     colors = [
@@ -97,12 +97,12 @@ for flavour, colours in palette.items():
         colours["teal"],
         isLatte and colours["surface1"] or colours["subtext0"],
     ]
-    gsettings_set_key("use-theme-colors", False, f"{uuid}")
+    gsettings_set("use-theme-colors", False, f"{uuid}")
     # get only the hex key from each entry in colors
-    gsettings_set_key("palette", [color["hex"] for color in colors], f"{uuid}")
+    gsettings_set("palette", [color["hex"] for color in colors], f"{uuid}")
 
     if uuid not in profiles:
         profiles.append(uuid)
 
-gsettings_set_key("list", profiles)
+gsettings_set("list", profiles)
 print("All profiles installed.")


### PR DESCRIPTION
### Problem
The dconf read command does not return the default gnome terminal profile uuid even if it was modified by the user which results in removing it from the terminal profiles list.

### Solution
I've modified the `dconf_get` function to use `gsettings get` command instead. The proposed solution handles the default profile uuid correctly. Also removed `os` from imports since it was not used anywhere in the script.