### PR TITLE
feat: add `uninstall.py` script

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,13 +35,17 @@
 </details>
 
 ## Usage
-
+### Install
 1. Make sure the `dconf` and `python3` commands are available on your system.
 2. Execute the `./install.py` script, either after cloning the repository, or via `curl`:
 ```bash
 curl -L https://raw.githubusercontent.com/catppuccin/gnome-terminal/v0.2.0/install.py | python3 -
 ```
 3. In Gnome Terminal, open `Edit -> Preferences`, and enable the profile for the theme you want.
+
+### Uninstall
+1. Make sure the `gsettings` and `python3` commands are available on your system.
+2. Execute the `./uninstall.py` script after cloning the repository.
 
 ## 💝 Thanks to
 

--- a/uninstall.py
+++ b/uninstall.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+import json
+import argparse
+from subprocess import check_output as run
+
+arg_parser = argparse.ArgumentParser(prog='Catppuccin Theme - Gnome-Terminal Uninstallation',
+                                     description='Uninstalls the catppuccin theme for gnome-terminal')
+args = arg_parser.parse_args()
+
+gsettings_path_base = "org.gnome.Terminal.Legacy.Profile:/org/gnome/terminal/legacy/profiles:/"
+gsettings_schema = "org.gnome.Terminal.ProfilesList"
+# hardcoded uuids for each flavour
+uuids = {
+    "mocha": "95894cfd-82f7-430d-af6e-84d168bc34f5",
+    "macchiato": "5083e06b-024e-46be-9cd2-892b814f1fc8",
+    "frappe": "71a9971e-e829-43a9-9b2f-4565c855d664",
+    "latte": "de8a9081-8352-4ce4-9519-5de655ad9361",
+}
+
+
+def gsettings_get(key: str):
+    return json.loads(
+        run(["gsettings", "get", gsettings_schema, key]).decode("utf-8").replace("'", '"')
+    )
+
+
+# filter out non-Catppuccin profiles
+try:
+    profiles = gsettings_get("list")
+except:
+    profiles = []
+other_profiles = []
+
+for uuid in profiles:
+    if uuid not in uuids.values():
+        other_profiles.append(uuid)
+        continue
+
+    print(f"Removing {uuid}")
+
+    run(["gsettings", "reset-recursively", f"{gsettings_path_base}:{uuid}/"])
+
+# reset the profiles list
+run(["gsettings", "set", f"{gsettings_schema}", "list", f"{other_profiles}"])
+
+print("Catppuccin profiles uninstalled.")


### PR DESCRIPTION
Added a script for uninstalling the Catppuccin profiles and updated the README instructions. The `curl` command requires creating a fresh tag so I left it out for now.